### PR TITLE
Using currentTarget instead of target

### DIFF
--- a/lib/domodule.js
+++ b/lib/domodule.js
@@ -110,7 +110,7 @@ class Domodule {
   }
 
   actionRouter(event) {
-    const actionEl = event.target;
+    const actionEl = event.currentTarget;
     const { name: actionName } = Domodule.parseAction(actionEl);
     const actionData = attrObj('action', actionEl);
 


### PR DESCRIPTION
This is actually a bug. Using `target` will get, sometimes, an element we’re not binding for and since we relay on the element to actually get the info for the action to run, this is wrong.

`currentTarget` is *always* the bound element.
`target` is where the event originated.